### PR TITLE
Enforce invalid training constraints

### DIFF
--- a/src/marin/utilities/unimax_weights.py
+++ b/src/marin/utilities/unimax_weights.py
@@ -24,9 +24,17 @@ def unimax_weights(
     if budget < 0:
         raise ValueError("budget must be non-negative")
 
+    if max_epochs <= 0:
+        raise ValueError("max_epochs must be positive")
+
+    if any(v < 0 for v in corpus_tokens.values()):
+        raise ValueError("corpus sizes must be non-negative")
+
     # Handle empty corpora early
     total_tokens = float(sum(corpus_tokens.values()))
     if total_tokens == 0:
+        if budget > 0:
+            raise ValueError("budget must be zero when corpus is empty")
         return {k: 0.0 for k in corpus_tokens}, {k: 0.0 for k in corpus_tokens}
 
     # If the requested budget is larger than the allowed max_epochs, bump it so

--- a/tests/test_unimax_weights.py
+++ b/tests/test_unimax_weights.py
@@ -1,0 +1,26 @@
+import pytest
+
+from marin.utilities.unimax_weights import unimax_weights
+
+
+def test_negative_budget():
+    with pytest.raises(ValueError):
+        unimax_weights({"a": 1}, budget=-1)
+
+
+def test_nonpositive_max_epochs():
+    with pytest.raises(ValueError):
+        unimax_weights({"a": 1}, budget=1, max_epochs=0)
+
+    with pytest.raises(ValueError):
+        unimax_weights({"a": 1}, budget=1, max_epochs=-1)
+
+
+def test_negative_corpus_size():
+    with pytest.raises(ValueError):
+        unimax_weights({"a": -1}, budget=1)
+
+
+def test_empty_corpus_nonzero_budget():
+    with pytest.raises(ValueError):
+        unimax_weights({"a": 0, "b": 0}, budget=1)


### PR DESCRIPTION
## Summary
- validate unimax_weights inputs: reject negative budget, nonpositive max_epochs, negative corpus sizes, and empty corpora with budget
- add tests for unimax_weights error handling